### PR TITLE
RIP MicrobeKraken

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![pando](http://upliftconnect.com/wp-content/uploads/2016/03/pando-trees-1.jpg)
+
 # pando
 With an excel spreadsheet LIMS request, run QC analyses on isolates
 

--- a/pando/__main__.py
+++ b/pando/__main__.py
@@ -711,7 +711,7 @@ def main():
             json = os.path.abspath(base+'_metadataAll.json')
             metadata_overall.to_csv(sys.stdout)
             writer = pd.ExcelWriter(EXCEL_OUT)
-            metadata_overall.to_excel(writer,'AMR_results', freeze_panes=(1, 1))
+            metadata_overall.to_excel(writer,'Sheet 1', freeze_panes=(1, 1))
             writer.save()
             print(f"\nResults written to {os.path.abspath(EXCEL_OUT)}")
 

--- a/pando/__main__.py
+++ b/pando/__main__.py
@@ -273,7 +273,7 @@ class Isolate(object):
         Get the kraken best hit from assemblies.
         '''
         #Pipe these commands together
-        cmd_kraken = 'nice kraken --threads 2 --db /home/linuxbrew/db/kraken//microbekraken'+\
+        cmd_kraken = 'nice kraken --threads 2 --db /home/linuxbrew/db/kraken/minikraken'+\
                      ' --fasta-input '+ARGS.wgs_qc+'/'+self.ID+'/contigs.fa'
         cmd_krk_r = 'kraken-report'
         cmd_grep = "grep -P '\tS\t'"


### PR DESCRIPTION
Here I switched out the reference to the `microbekraken` db (which was deleted in the recent space-winning disk-purge) for the `minikraken` db that replaced it.

I also changed the name of the sheet in the `xlsx` output from the informative 'AMR_results' to the Excel-macro-compatible 'Sheet 1' to avoid having to do this by hand every time.